### PR TITLE
workaround for slow asJSON matrix method

### DIFF
--- a/pkg/rglwidget/R/convertScene.R
+++ b/pkg/rglwidget/R/convertScene.R
@@ -425,6 +425,18 @@ convertScene <- function(x = scene3d(), width = NULL, height = NULL, reuse = NUL
                      data.frame(id = -1, elementId = elementId,
                                 texture = "", stringsAsFactors = FALSE))
 	}
+	
+	# slow jsonlite workaround convert big matrices to data.frames
+	# the json output will be the same if toJSON(dataframe = "rows")
+	convert_matrix_df<-function(x) {
+	  if(is.list(x) && length(x)) {
+	    return(sapply(x, convert_matrix_df, simplify = FALSE))
+	  }
+	  if(!is.matrix(x) || nrow(x)<10) return(x)
+	  unname(as.data.frame(x))
+	}
+	result$objects=convert_matrix_df(result$objects)
+	
 	structure(result, reuse = reuseDF)
 }
 

--- a/pkg/rglwidget/R/webGL.R
+++ b/pkg/rglwidget/R/webGL.R
@@ -80,7 +80,7 @@ subst <- function(strings, ..., digits=7) {
 
   reuse <- attr(scene, "reuse")
   json <- toJSON(I(scene),
-                 dataframe = "columns", null = "null", na = "null",
+                 dataframe = "rows", null = "null", na = "null",
                  auto_unbox = TRUE, digits = getOption("shiny.json.digits",
                                                        7),
                  use_signif = TRUE, force = TRUE, POSIXt = "ISO8601",


### PR DESCRIPTION
- as proposed by Jeroen Ooms
- bit worried that toJSON(,dataframe="rows") could have unintended 
  consequences
