### PR TITLE
vertexControl documentation - 'radius' is not a valid attribute, must be radii

### DIFF
--- a/branches/CRAN/man/vertexControl.Rd
+++ b/branches/CRAN/man/vertexControl.Rd
@@ -25,7 +25,7 @@ the number of vertices in the \code{objid}.
 }
   \item{attributes}{A vector of attributes of a vertex,
   from \code{c("x", "y", "z", "red", "green", "blue", "alpha", "nx", "ny", "nz",
-               "radius", "ox", "oy", "oz", "ts", "tt", "offset")}.  See
+               "radii", "ox", "oy", "oz", "ts", "tt", "offset")}.  See
                Details.}
   \item{objid}{
 A single \pkg{rgl} object id.

--- a/pkg/rgl/man/vertexControl.Rd
+++ b/pkg/rgl/man/vertexControl.Rd
@@ -25,7 +25,7 @@ the number of vertices in the \code{objid}.
 }
   \item{attributes}{A vector of attributes of a vertex,
   from \code{c("x", "y", "z", "red", "green", "blue", "alpha", "nx", "ny", "nz",
-               "radius", "ox", "oy", "oz", "ts", "tt", "offset")}.  See
+               "radii", "ox", "oy", "oz", "ts", "tt", "offset")}.  See
                Details.}
   \item{objid}{
 A single \pkg{rgl} object id.


### PR DESCRIPTION
Discovered this while playing with vertexControl